### PR TITLE
Add support to sort track-Oids

### DIFF
--- a/ttaenc/Package.cs
+++ b/ttaenc/Package.cs
@@ -75,6 +75,23 @@ namespace ttaenc
 
         public int NextOid {get; set; }
 
+        bool sortOid = false;
+
+        public bool SortOid {
+            get
+            {
+                return sortOid;
+            }
+            set
+            {
+                sortOid = value;
+                if (sortOid)
+                {
+                    ReOid();
+                }
+            }
+        }
+
         public int GetNextOid()
         {
             return NextOid++;
@@ -138,6 +155,20 @@ namespace ttaenc
                 .OrderBy(_ => _.Album)
                 .ThenBy(_ => _.TrackNumber)
                 .ToArray();
+
+            if (SortOid)
+            {
+                ReOid();
+            }
+        }
+
+        public void ReOid()
+        {
+            NextOid = StopOid + 1;
+            foreach(var track in Tracks)
+            {
+                track.Oid = this.GetNextOid();
+            }
         }
 
         public void RemoveTracks(IEnumerable<Track> enumerable)

--- a/ttaudio/Editor.Designer.cs
+++ b/ttaudio/Editor.Designer.cs
@@ -53,6 +53,8 @@
             this.label2 = new System.Windows.Forms.Label();
             this.textBoxProductId = new System.Windows.Forms.TextBox();
             this.toolStripContainer1 = new System.Windows.Forms.ToolStripContainer();
+            this.checkBoxOrderOid = new System.Windows.Forms.CheckBox();
+            this.label5 = new System.Windows.Forms.Label();
             this.comboBoxPlaybackMode = new System.Windows.Forms.ComboBox();
             this.label4 = new System.Windows.Forms.Label();
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
@@ -285,6 +287,8 @@
             // 
             // toolStripContainer1.ContentPanel
             // 
+            this.toolStripContainer1.ContentPanel.Controls.Add(this.checkBoxOrderOid);
+            this.toolStripContainer1.ContentPanel.Controls.Add(this.label5);
             this.toolStripContainer1.ContentPanel.Controls.Add(this.comboBoxPlaybackMode);
             this.toolStripContainer1.ContentPanel.Controls.Add(this.label3);
             this.toolStripContainer1.ContentPanel.Controls.Add(this.textBoxProductId);
@@ -333,6 +337,25 @@
             this.label4.TabIndex = 3;
             this.label4.Text = "Playback Mode";
             // 
+            // checkBoxOrderOid
+            //
+            this.checkBoxOrderOid.AutoSize = true;
+            this.checkBoxOrderOid.Location = new System.Drawing.Point(78, 62);
+            this.checkBoxOrderOid.Name = "checkBoxOrderOid";
+            this.checkBoxOrderOid.Size = new System.Drawing.Size(141, 17);
+            this.checkBoxOrderOid.TabIndex = 8;
+            this.checkBoxOrderOid.Text = "Keep track-Oids ordered";
+            this.checkBoxOrderOid.UseVisualStyleBackColor = true;
+            this.checkBoxOrderOid.CheckedChanged += new System.EventHandler(this.checkBoxOrderOid_CheckedChanged);
+            //
+            // label5
+            //
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(12, 63);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(45, 13);
+            this.label5.TabIndex = 8;
+            this.label5.Text = "Settings";
             // toolStrip1
             // 
             this.toolStrip1.Dock = System.Windows.Forms.DockStyle.None;
@@ -438,6 +461,8 @@
         private System.Windows.Forms.ToolStripButton toolStripButtonPrint;
         private System.Windows.Forms.ComboBox comboBoxPlaybackMode;
         private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.CheckBox checkBoxOrderOid;
+        private System.Windows.Forms.Label label5;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripMenuItem optionsToolStripMenuItem;
     }

--- a/ttaudio/Editor.cs
+++ b/ttaudio/Editor.cs
@@ -214,6 +214,8 @@ namespace ttaudio
 
             this.comboBoxPlaybackMode.SelectedIndex = (int) p.PlaybackMode;
 
+            this.checkBoxOrderOid.Checked = p.SortOid;
+
             this.Text = String.Join(" - ", new string[] { About.Product, this.document.ttaFile }
                 .Where(_ => !String.IsNullOrEmpty(_)));
         }
@@ -235,6 +237,7 @@ namespace ttaudio
                     p.ProductId = productId;
                 }
                 p.PlaybackMode = (PlaybackModes)this.comboBoxPlaybackMode.SelectedIndex;
+                p.SortOid = this.checkBoxOrderOid.Checked;
             }
         }
 
@@ -406,7 +409,12 @@ namespace ttaudio
 
         private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
         {
+        }
 
+        private void checkBoxOrderOid_CheckedChanged(object sender, EventArgs e)
+        {
+            UpdateModel(); // Updating the model, will also sort the tracks
+            UpdateView();
         }
 
         private void optionsToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
Being able to sort the Oids allows to reuse the Oid to select a track. 
For example: Have one side of a card to select the album and the other to select the track of the album.